### PR TITLE
Update UniCommandLineParser.asmdef

### DIFF
--- a/Editor/UniCommandLineParser.asmdef
+++ b/Editor/UniCommandLineParser.asmdef
@@ -1,9 +1,7 @@
 {
     "name": "UniCommandLineParser",
     "references": [],
-    "includePlatforms": [
-        "Editor"
-    ],
+    "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
@@ -11,5 +9,5 @@
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
-    "noEngineReferences": false
+    "noEngineReferences": true
 }


### PR DESCRIPTION
- Disable engine references, since this assembly doesn't use UnityEngine (it'll compile faster)
- Allow this library to be used on any platform, since it doesn't use UnityEditor